### PR TITLE
fix: update broken link proof-generation.md

### DIFF
--- a/docs/concepts/proof-generation.md
+++ b/docs/concepts/proof-generation.md
@@ -38,7 +38,7 @@ Hylé currently supports the following zero-knowledge proving schemes:
 
 - [Noir](https://noir-lang.org/docs/)
 - [Risc0](https://risc0.com/docs/)
-- [SP1](https://docs.succinct.xyz/docs/introduction)
+- [SP1](https://docs.succinct.xyz/docs/sp1/introduction)
 
 We also verify these natively, without the need for a ZK proof.
 


### PR DESCRIPTION
Hi! I fixes a broken link in the `docs/concepts/proof-generation.md` file. The outdated link to the SP1 documentation has been updated to point to the correct and current location.